### PR TITLE
fix: replace path dependencies with pub versions for publishable packages

### DIFF
--- a/.github/workflows/groveman_analytics_mixpanel.yaml
+++ b/.github/workflows/groveman_analytics_mixpanel.yaml
@@ -62,4 +62,4 @@ jobs:
           flutter pub global activate pana
 
       - name: Verify Pub Score
-        run: ../../scripts/verify_pub_score.sh
+        run: ../../scripts/verify_pub_score.sh 150

--- a/.github/workflows/groveman_analytics_posthog.yaml
+++ b/.github/workflows/groveman_analytics_posthog.yaml
@@ -62,4 +62,4 @@ jobs:
           flutter pub global activate pana
 
       - name: Verify Pub Score
-        run: ../../scripts/verify_pub_score.sh
+        run: ../../scripts/verify_pub_score.sh 150

--- a/packages/groveman_analytics_firebase/example/pubspec.yaml
+++ b/packages/groveman_analytics_firebase/example/pubspec.yaml
@@ -13,8 +13,7 @@ dependencies:
   firebase_core: ^4.10.0
   flutter:
     sdk: flutter
-  groveman_analytics:
-    path: ../../groveman_analytics
+  groveman_analytics: ^0.1.0
   groveman_analytics_firebase:
     path: ../
 

--- a/packages/groveman_analytics_firebase/pubspec.yaml
+++ b/packages/groveman_analytics_firebase/pubspec.yaml
@@ -17,8 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   firebase_analytics: ^12.0.0
-  groveman_analytics:
-    path: ../groveman_analytics
+  groveman_analytics: ^0.1.0
 
 dev_dependencies:
   firebase_analytics_platform_interface: ^6.0.2

--- a/packages/groveman_analytics_firebase/pubspec.yaml
+++ b/packages/groveman_analytics_firebase/pubspec.yaml
@@ -14,9 +14,9 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
+  firebase_analytics: ^12.0.0
   flutter:
     sdk: flutter
-  firebase_analytics: ^12.0.0
   groveman_analytics: ^0.1.0
 
 dev_dependencies:

--- a/packages/groveman_analytics_mixpanel/example/pubspec.yaml
+++ b/packages/groveman_analytics_mixpanel/example/pubspec.yaml
@@ -11,8 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  groveman_analytics:
-    path: ../../groveman_analytics
+  groveman_analytics: ^0.1.0
   groveman_analytics_mixpanel:
     path: ../
   mixpanel_flutter: ^2.0.0

--- a/packages/groveman_analytics_mixpanel/pubspec.yaml
+++ b/packages/groveman_analytics_mixpanel/pubspec.yaml
@@ -16,8 +16,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  groveman_analytics:
-    path: ../groveman_analytics
+  groveman_analytics: ^0.1.0
   mixpanel_flutter: ^2.0.0
 
 dev_dependencies:

--- a/packages/groveman_analytics_mixpanel/pubspec.yaml
+++ b/packages/groveman_analytics_mixpanel/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   groveman_analytics: ^0.1.0
-  mixpanel_flutter: ^2.0.0
+  mixpanel_flutter: ^2.10.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/groveman_analytics_posthog/example/pubspec.yaml
+++ b/packages/groveman_analytics_posthog/example/pubspec.yaml
@@ -11,8 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  groveman_analytics:
-    path: ../../groveman_analytics
+  groveman_analytics: ^0.1.0
   groveman_analytics_posthog:
     path: ../
   posthog_flutter: ^5.0.0

--- a/packages/groveman_analytics_posthog/pubspec.yaml
+++ b/packages/groveman_analytics_posthog/pubspec.yaml
@@ -16,8 +16,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  groveman_analytics:
-    path: ../groveman_analytics
+  groveman_analytics: ^0.1.0
   posthog_flutter: ^5.0.0
 
 dev_dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the analytics integration packages and examples to depend on the published `groveman_analytics` version instead of local path references.
  * Increased the Mixpanel Flutter dependency version for the Mixpanel integration.
* **Chores**
  * Updated CI “Verify Pub Score” steps to pass an explicit threshold value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->